### PR TITLE
make syncAllWithRemote() a class method of Widget instead of AppDelegate

### DIFF
--- a/loopback-swift-realm-example/AppDelegate.swift
+++ b/loopback-swift-realm-example/AppDelegate.swift
@@ -17,35 +17,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     static let adapter = LBRESTAdapter(URL: NSURL(string: "http://localhost:3000"))
     static let widgetRepository = adapter.repositoryWithClass(WidgetRemoteRepository) as! WidgetRemoteRepository
     
-    static func syncAllWithRemote() {
-        let realm = try! Realm()
-        // Sort descending to remove potentially expired local widgets
-        // that got removed from the backend before assigning new ids (avoids id conflicts)
-        let widgets = realm.objects(Widget).sorted("remoteId", ascending: false)
-        for widget in widgets {
-            widget.syncWithRemote()
-        }
-        // Get new widgets from remote
-        AppDelegate.widgetRepository.allWithSuccess({ (models: [AnyObject]!) -> Void in
-            let widgets = models as! [WidgetRemote]
-            for widget in widgets {
-                let predicate = NSPredicate(format: "remoteId == %d", widget._id as! Int)
-                let localWidget = realm.objects(Widget).filter(predicate)
-                if (localWidget.count == 0) {
-                    try! realm.write    {
-                        let newWidget = Widget(remoteWidget: widget)
-                        realm.add(newWidget)
-                    }
-                }
-            }
-            }) { (err: NSError!) -> Void in
-                NSLog(err.description)
-        }
-
-    }
-    
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
-        AppDelegate.syncAllWithRemote()
+        Widget.syncAllWithRemote()
         return true
     }
 

--- a/loopback-swift-realm-example/WidgetRemote.swift
+++ b/loopback-swift-realm-example/WidgetRemote.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2016 kevingoedecke. All rights reserved.
 //
 
-import Foundation
 import LoopBack
 
 class WidgetRemote : LBPersistedModel {

--- a/loopback-swift-realm-example/WidgetRemoteRepository.swift
+++ b/loopback-swift-realm-example/WidgetRemoteRepository.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2016 kevingoedecke. All rights reserved.
 //
 
-import Foundation
 import LoopBack
 
 class WidgetRemoteRepository : LBPersistedModelRepository     {

--- a/loopback-swift-realm-example/WidgetTableViewController.swift
+++ b/loopback-swift-realm-example/WidgetTableViewController.swift
@@ -36,7 +36,7 @@ class WidgetTableViewController: UITableViewController {
     
     func refresh(sender:AnyObject)
     {
-        AppDelegate.syncAllWithRemote()
+        Widget.syncAllWithRemote()
         self.refreshControl?.endRefreshing()
     }
 


### PR DESCRIPTION
I thought syncAllWithRemote() is better be a class method of Widget.

I think all the logic connecting between realm and LB would better be moved into another abstraction, at the same time removing the direct reference to AppDelegate from Widget or the newly introduced abstraction.  What would you think?
